### PR TITLE
Clang feature branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,9 +298,9 @@ if(NOT CMAKE_CROSSCOMPILING)
     endif(NOT NEON_HARDFP_SUPPORTED AND NOT NEON_SOFTFP_SUPPORTED)
   else()
     # enable SSE code generation
-    if(CMAKE_COMPILER_IS_GNUCC)
+    if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" )
       set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS_SAVE} -msse")
-    endif(CMAKE_COMPILER_IS_GNUCC)
+    endif("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" )
 
     # check if the platform has support for SSE intrinsics
     check_include_file(xmmintrin.h HAVE_XMMINTRIN_H)
@@ -310,9 +310,9 @@ if(NOT CMAKE_CROSSCOMPILING)
     endif(HAVE_XMMINTRIN_H)
 
     # enable SSE2 code generation
-    if(CMAKE_COMPILER_IS_GNUCC)
+    if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" )
       set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS_SAVE} -msse2")
-    endif(CMAKE_COMPILER_IS_GNUCC)
+    endif("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" )
 
     # check if the platform has support for SSE2 intrinsics
     check_include_file(emmintrin.h HAVE_EMMINTRIN_H)
@@ -322,9 +322,9 @@ if(NOT CMAKE_CROSSCOMPILING)
     endif(HAVE_EMMINTRIN_H)
 
     # enable SSE3 code generation
-    if(CMAKE_COMPILER_IS_GNUCC)
+    if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" )
       set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS_SAVE} -msse3")
-    endif(CMAKE_COMPILER_IS_GNUCC)
+    endif("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" )
 
     # check if the platform has support for SSE3 intrinsics
     check_include_file(pmmintrin.h HAVE_PMMINTRIN_H)
@@ -371,7 +371,7 @@ if(MSVC)
   set(CMAKE_DEBUG_POSTFIX "d")
 
   add_definitions(-D_USE_MATH_DEFINES)
-elseif(CMAKE_COMPILER_IS_GNUCC)
+elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" )
   include(CheckCCompilerFlag)
   include(CheckLibraryExists)
 

--- a/src/ffts_trig.c
+++ b/src/ffts_trig.c
@@ -881,7 +881,7 @@ int
 ffts_generate_cosine_sine_pow2_32f(ffts_cpx_32f *const table, int table_size)
 {
     const ffts_cpx_64f *FFTS_RESTRICT ct;
-    const double_t *FFTS_RESTRICT hs;
+    const ffts_double_t *FFTS_RESTRICT hs;
     ffts_cpx_64f FFTS_ALIGN(16) w[32];
     int i, log_2, offset;
 


### PR DESCRIPTION
Builds on FreeBSD 11.2 with clang 6. Output from ffts_test:

 Sign |      Size |     L2 Error
------+-----------+-------------
  -1  |         2 | 8.659561E-17
  -1  |         4 | 1.145552E-16
  -1  |         8 | 1.210162E-08
  -1  |        16 | 2.220916E-08
  -1  |        32 | 2.396272E-08
  -1  |        64 | 2.272872E-08
  -1  |       128 | 1.940460E-08
  -1  |       256 | 2.081312E-08
  -1  |       512 | 2.045939E-08
  -1  |      1024 | 2.079071E-08
  -1  |      2048 | 2.074052E-08
  -1  |      4096 | 2.124981E-08
  -1  |      8192 | 2.086463E-08
  -1  |     16384 | 2.071494E-08
  -1  |     32768 | 2.062090E-08
  -1  |     65536 | 2.054694E-08
  -1  |    131072 | 2.060355E-08
  -1  |    262144 | 2.054523E-08
   1  |         2 | 8.659561E-17
   1  |         4 | 1.145552E-16
   1  |         8 | 1.210162E-08
   1  |        16 | 2.220916E-08
   1  |        32 | 2.396272E-08
   1  |        64 | 2.272872E-08
   1  |       128 | 1.940460E-08
   1  |       256 | 2.081312E-08
   1  |       512 | 2.045939E-08
   1  |      1024 | 2.079071E-08
   1  |      2048 | 2.074052E-08
   1  |      4096 | 2.124981E-08
   1  |      8192 | 2.086463E-08
   1  |     16384 | 2.071494E-08
   1  |     32768 | 2.062090E-08
   1  |     65536 | 2.054694E-08
   1  |    131072 | 2.060355E-08
   1  |    262144 | 2.054523E-08
