### PR TITLE
Ensure aligned_alloc is in 32 byte chunks

### DIFF
--- a/src/ffts_internal.h
+++ b/src/ffts_internal.h
@@ -209,7 +209,7 @@ ffts_aligned_malloc(size_t size)
 
     /* various ways to allocate aligned memory in order of preferance */
 #if defined(HAVE_ALIGNED_ALLOC)
-    p = aligned_alloc(32, size);
+    p = aligned_alloc(32, size + (size % 32));
 #elif defined(__ICC) || defined(__INTEL_COMPILER) || defined(HAVE__MM_MALLOC)
     p = (void*) _mm_malloc(size, 32);
 #elif defined(HAVE_POSIX_MEMALIGN)

--- a/src/ffts_internal.h
+++ b/src/ffts_internal.h
@@ -209,7 +209,7 @@ ffts_aligned_malloc(size_t size)
 
     /* various ways to allocate aligned memory in order of preferance */
 #if defined(HAVE_ALIGNED_ALLOC)
-    p = aligned_alloc(32, size + (size % 32));
+    p = aligned_alloc(32, ((size + 32 - 1) / 32) * 32);
 #elif defined(__ICC) || defined(__INTEL_COMPILER) || defined(HAVE__MM_MALLOC)
     p = (void*) _mm_malloc(size, 32);
 #elif defined(HAVE_POSIX_MEMALIGN)


### PR DESCRIPTION
* The C++ standard does not define what happens if the size is not a multiple of the integral
* In macOS Big Sur this results in a NULL output
* This makes it impossible to use ffts_init_1d_real on this platform due to the size passed never being an integral of 32