### PR TITLE
Fix an oversight in 92c8a59d

### DIFF
--- a/src/ffts_trig.c
+++ b/src/ffts_trig.c
@@ -881,7 +881,7 @@ int
 ffts_generate_cosine_sine_pow2_32f(ffts_cpx_32f *const table, int table_size)
 {
     const ffts_cpx_64f *FFTS_RESTRICT ct;
-    const double_t *FFTS_RESTRICT hs;
+    const ffts_double_t *FFTS_RESTRICT hs;
     ffts_cpx_64f FFTS_ALIGN(16) w[32];
     int i, log_2, offset;
 


### PR DESCRIPTION
This seems to have been a small oversight while replacing `double` with `ffts_double_t`.